### PR TITLE
Restart Supabase auth refresh on tab change

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -82,18 +82,25 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     };
 
     const onFocus = () => {
+      supabase.auth.startAutoRefresh();
       // Debounce to avoid rate limiting
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => void rehydrate(), 1000);
     };
-    
+
     const onVis = () => {
       if (document.visibilityState === 'visible') {
+        supabase.auth.startAutoRefresh();
         clearTimeout(timeoutId);
         timeoutId = setTimeout(() => void rehydrate(), 1000);
+      } else {
+        // Pause auto refresh when tab is hidden to avoid rate limiting
+        supabase.auth.stopAutoRefresh();
       }
     };
 
+    // Ensure auto refresh is active when this effect runs
+    supabase.auth.startAutoRefresh();
     window.addEventListener('focus', onFocus);
     document.addEventListener('visibilitychange', onVis);
     
@@ -101,6 +108,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       clearTimeout(timeoutId);
       window.removeEventListener('focus', onFocus);
       document.removeEventListener('visibilitychange', onVis);
+      supabase.auth.stopAutoRefresh();
     };
   }, [session]);
 


### PR DESCRIPTION
## Summary
- restart Supabase auto refresh when tab regains focus
- pause auto refresh when tab hidden to avoid rate limiting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / lexical declarations in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a78eda239083218e1bbf98946ab22f