### PR TITLE
Refresh Supabase session on tab focus

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,12 @@
-import { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { ReactNode } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 
@@ -24,7 +32,7 @@ type AuthState = {
 
 const AuthContext = createContext<AuthState>({} as any);
 
-export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -150,7 +158,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     loading, signIn, signUp, signOut
   }), [session, user, profile, loading]);
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return (
+    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  );
 };
 
 export const useAuth = () => useContext(AuthContext);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -48,59 +48,43 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     return () => { mounted = false; sub.subscription.unsubscribe(); };
   }, []);
 
-  // 2) gentle session recovery (avoid rate limiting)
+  // 2) keep session fresh when user returns to the tab
   useEffect(() => {
-    let timeoutId: NodeJS.Timeout;
-    
-    const rehydrate = async () => {
+    const refresh = async () => {
       if (refRefreshing.current) return;
       refRefreshing.current = true;
-      
+
       try {
-        const { data } = await supabase.auth.getSession();
+        const { data } = await supabase.auth.refreshSession();
         if (data.session) {
           setSession(data.session);
           setUser(data.session.user);
         } else {
-          // Only try refresh if we don't have a session and had one before
-          if (session) {
-            const refreshResult = await supabase.auth.refreshSession();
-            if (refreshResult.data.session) {
-              setSession(refreshResult.data.session);
-              setUser(refreshResult.data.session.user);
-            } else {
-              setSession(null);
-              setUser(null);
-            }
-          }
+          setSession(null);
+          setUser(null);
         }
       } catch (error) {
-        console.warn('Session rehydration failed:', error);
+        console.warn('Session refresh failed:', error);
       } finally {
         refRefreshing.current = false;
       }
     };
 
-    const onFocus = () => {
-      // Debounce to avoid rate limiting
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(() => void rehydrate(), 1000);
-    };
-    
-    const onVis = () => {
+    const handleVisibility = () => {
       if (document.visibilityState === 'visible') {
-        clearTimeout(timeoutId);
-        timeoutId = setTimeout(() => void rehydrate(), 1000);
+        supabase.auth.startAutoRefresh();
+        void refresh();
       }
     };
 
-    window.addEventListener('focus', onFocus);
-    document.addEventListener('visibilitychange', onVis);
-    
+    supabase.auth.startAutoRefresh();
+    window.addEventListener('focus', handleVisibility);
+    document.addEventListener('visibilitychange', handleVisibility);
+
     return () => {
-      clearTimeout(timeoutId);
-      window.removeEventListener('focus', onFocus);
-      document.removeEventListener('visibilitychange', onVis);
+      window.removeEventListener('focus', handleVisibility);
+      document.removeEventListener('visibilitychange', handleVisibility);
+      supabase.auth.stopAutoRefresh();
     };
   }, [session]);
 


### PR DESCRIPTION
## Summary
- refresh Supabase auth session whenever browser tab becomes visible
- ensure auto refresh resumes on focus to keep database access alive

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / lexical declaration errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a78eda239083218e1bbf98946ab22f